### PR TITLE
Fix 2020 budgets

### DIFF
--- a/operations/gobierto_budgets/transform-planned/run.rb
+++ b/operations/gobierto_budgets/transform-planned/run.rb
@@ -55,14 +55,10 @@ def parse_amount(row, year)
 end
 
 def parse_cell(row, year, name)
-  #return if row['PARANYPRS'].to_i != year
-
   return if year == 2020 && row["IMPASSIG_V2"].blank?
   return if year != 2020 && row["IMPASSIG_V1"].blank?
-
-  #return if row['IMPASSIG'].blank?
-
   return if row[name].blank?
+
   category_name = row[name].strip
 
   if row['TIPPARTIDA'].strip == 'Despeses'

--- a/operations/gobierto_budgets/transform-planned/run.rb
+++ b/operations/gobierto_budgets/transform-planned/run.rb
@@ -48,6 +48,12 @@ base_data = {
 
 output_data = []
 
+def parse_amount(row, year)
+  cell_value = (year == 2020) ? row["IMPASSIG_V2"] : row["IMPASSIG_V1"]
+
+  cell_value.tr(",", ".").to_f
+end
+
 def parse_cell(row, year, name)
   #return if row['PARANYPRS'].to_i != year
   return if row['IMPASSIG'].blank?
@@ -77,7 +83,7 @@ def parse_cell(row, year, name)
   end
 
   @categories[kind][category_code] ||= 0
-  @categories[kind][category_code] += row['IMPASSIG'].tr(',', '.').to_f
+  @categories[kind][category_code] += parse_amount(row, year)
   @categories[kind][category_code] = @categories[kind][category_code].round(2)
 
   # Extract economic information from PARCAPITOL
@@ -86,7 +92,7 @@ def parse_cell(row, year, name)
     economic_category_code = $1.strip
     @economic_categories[kind][category_code] ||= {}
     @economic_categories[kind][category_code][economic_category_code] ||= 0
-    @economic_categories[kind][category_code][economic_category_code] += row['IMPASSIG'].tr(',', '.').to_f
+    @economic_categories[kind][category_code][economic_category_code] += parse_amount(row, year)
   end
 end
 

--- a/operations/gobierto_budgets/transform-planned/run.rb
+++ b/operations/gobierto_budgets/transform-planned/run.rb
@@ -56,7 +56,12 @@ end
 
 def parse_cell(row, year, name)
   #return if row['PARANYPRS'].to_i != year
-  return if row['IMPASSIG'].blank?
+
+  return if year == 2020 && row["IMPASSIG_V2"].blank?
+  return if year != 2020 && row["IMPASSIG_V1"].blank?
+
+  #return if row['IMPASSIG'].blank?
+
   return if row[name].blank?
   category_name = row[name].strip
 

--- a/operations/gobierto_budgets/transform-planned/run.rb
+++ b/operations/gobierto_budgets/transform-planned/run.rb
@@ -35,7 +35,7 @@ year = ARGV[2].to_i
 puts "[START] transform-planned/run.rb with file=#{input_file} output=#{output_file} year=#{year}"
 
 place = INE::Places::Place.find_by_slug('mataro')
-population = GobiertoData::GobiertoBudgets::Population.get(place.id, year)
+population = GobiertoData::GobiertoBudgets::Population.get(place.id, year) || GobiertoData::GobiertoBudgets::Population.get(place.id, year - 1)
 
 base_data = {
   organization_id: place.id,
@@ -49,7 +49,7 @@ base_data = {
 output_data = []
 
 def parse_cell(row, year, name)
-  return if row['PARANYPRS'].to_i != year
+  #return if row['PARANYPRS'].to_i != year
   return if row['IMPASSIG'].blank?
   return if row[name].blank?
   category_name = row[name].strip

--- a/pipelines/budgets/Jenkinsfile
+++ b/pipelines/budgets/Jenkinsfile
@@ -16,34 +16,57 @@ pipeline {
               sh "rm -rf ${WORKING_DIR}"
           }
         }
+        stage('Create organization file') {
+            steps {
+              sh "echo '8121' > ${WORKING_DIR}/organization.id.txt"
+            }
+        }
+        stage('Clear previous data') {
+            steps {
+              sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/clear-budgets/run.rb ${WORKING_DIR}/organization.id.txt 2018"
+              sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/clear-budgets/run.rb ${WORKING_DIR}/organization.id.txt 2019"
+              sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/clear-budgets/run.rb ${WORKING_DIR}/organization.id.txt 2020"
+              sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/clear-budgets/run.rb ${WORKING_DIR}/organization.id.txt 2021"
+            }
+        }
         stage('Extract > Download data sources') {
             steps {
                 sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/download/run.rb 'http://dadesobertes.mataro.cat/pressupost_2018.csv' ${WORKING_DIR}/pressupost_2018.csv"
                 sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/download/run.rb 'http://dadesobertes.mataro.cat/pressupost_2019.csv' ${WORKING_DIR}/pressupost_2019.csv"
+                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/download/run.rb 'http://dadesobertes.mataro.cat/pressupost_2020.csv' ${WORKING_DIR}/pressupost_2020.csv"
+                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/download/run.rb 'http://dadesobertes.mataro.cat/avant_pressupost_2020.csv' ${WORKING_DIR}/avant_pressupost_2020.csv"
             }
         }
         stage('Extract > Convert data to UTF8') {
             steps {
                 sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/convert-to-utf8/run.rb ${WORKING_DIR}/pressupost_2018.csv ${WORKING_DIR}/pressupost_2018_utf8.csv ISO-8859-1"
                 sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/convert-to-utf8/run.rb ${WORKING_DIR}/pressupost_2019.csv ${WORKING_DIR}/pressupost_2019_utf8.csv ISO-8859-1"
+                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/convert-to-utf8/run.rb ${WORKING_DIR}/pressupost_2020.csv ${WORKING_DIR}/pressupost_2020_utf8.csv ISO-8859-1"
+                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/convert-to-utf8/run.rb ${WORKING_DIR}/avant_pressupost_2020.csv ${WORKING_DIR}/avant_pressupost_2020_utf8.csv ISO-8859-1"
             }
         }
         stage('Extract > Clean wrong quotes') {
             steps {
                 sh "cd ${MATARO_ETL}; ruby operations/gobierto_budgets/clean-quotes/run.rb ${WORKING_DIR}/pressupost_2018_utf8.csv ${WORKING_DIR}/pressupost_2018_utf8_clean.csv"
                 sh "cd ${MATARO_ETL}; ruby operations/gobierto_budgets/clean-quotes/run.rb ${WORKING_DIR}/pressupost_2019_utf8.csv ${WORKING_DIR}/pressupost_2019_utf8_clean.csv"
+                sh "cd ${MATARO_ETL}; ruby operations/gobierto_budgets/clean-quotes/run.rb ${WORKING_DIR}/pressupost_2020_utf8.csv ${WORKING_DIR}/pressupost_2020_utf8_clean.csv"
+                sh "cd ${MATARO_ETL}; ruby operations/gobierto_budgets/clean-quotes/run.rb ${WORKING_DIR}/avant_pressupost_2020_utf8.csv ${WORKING_DIR}/avant_pressupost_2020_utf8_clean.csv"
             }
         }
         stage('Extract > Check CSV format') {
             steps {
                 sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/check-csv/run.rb ${WORKING_DIR}/pressupost_2018_utf8_clean.csv"
                 sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/check-csv/run.rb ${WORKING_DIR}/pressupost_2019_utf8_clean.csv"
+                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/check-csv/run.rb ${WORKING_DIR}/pressupost_2020_utf8_clean.csv"
+                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/check-csv/run.rb ${WORKING_DIR}/avant_pressupost_2020_utf8_clean.csv"
             }
         }
         stage('Transform > Transform planned budgets data files') {
             steps {
                 sh "cd ${MATARO_ETL}; ruby operations/gobierto_budgets/transform-planned/run.rb ${WORKING_DIR}/pressupost_2018_utf8_clean.csv ${WORKING_DIR}/budgets-planned-2018-transformed.json 2018"
                 sh "cd ${MATARO_ETL}; ruby operations/gobierto_budgets/transform-planned/run.rb ${WORKING_DIR}/pressupost_2019_utf8_clean.csv ${WORKING_DIR}/budgets-planned-2019-transformed.json 2019"
+                sh "cd ${MATARO_ETL}; ruby operations/gobierto_budgets/transform-planned/run.rb ${WORKING_DIR}/pressupost_2020_utf8_clean.csv ${WORKING_DIR}/budgets-planned-2020-transformed.json 2020"
+                sh "cd ${MATARO_ETL}; ruby operations/gobierto_budgets/transform-planned/run.rb ${WORKING_DIR}/avant_pressupost_2020_utf8_clean.csv ${WORKING_DIR}/budgets-planned-2021-transformed.json 2021"
             }
         }
         stage('Transform > Transform executed budgets data files') {
@@ -62,6 +85,8 @@ pipeline {
             steps {
                 sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/import-planned-budgets/run.rb ${WORKING_DIR}/budgets-planned-2018-transformed.json 2018"
                 sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/import-planned-budgets/run.rb ${WORKING_DIR}/budgets-planned-2019-transformed.json 2019"
+                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/import-planned-budgets/run.rb ${WORKING_DIR}/budgets-planned-2020-transformed.json 2020"
+                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/import-planned-budgets/run.rb ${WORKING_DIR}/budgets-planned-2021-transformed.json 2021"
             }
         }
         stage('Load > Import executed budgets') {
@@ -78,14 +103,15 @@ pipeline {
         }
         stage('Load > Import custom categories') {
             steps {
-                sh "cd ${GOBIERTO}; bin/rails runner ${MATARO_ETL}/operations/gobierto_budgets/extract-custom-categories/run.rb ${WORKING_DIR}/pressupost_2019_utf8_clean.csv ${DOMAIN}"
                 sh "cd ${GOBIERTO}; bin/rails runner ${MATARO_ETL}/operations/gobierto_budgets/extract-custom-categories/run.rb ${WORKING_DIR}/pressupost_2018_utf8_clean.csv ${DOMAIN}"
+                sh "cd ${GOBIERTO}; bin/rails runner ${MATARO_ETL}/operations/gobierto_budgets/extract-custom-categories/run.rb ${WORKING_DIR}/pressupost_2019_utf8_clean.csv ${DOMAIN}"
+                sh "cd ${GOBIERTO}; bin/rails runner ${MATARO_ETL}/operations/gobierto_budgets/extract-custom-categories/run.rb ${WORKING_DIR}/pressupost_2020_utf8_clean.csv ${DOMAIN}"
+                sh "cd ${GOBIERTO}; bin/rails runner ${MATARO_ETL}/operations/gobierto_budgets/extract-custom-categories/run.rb ${WORKING_DIR}/avant_pressupost_2020_utf8_clean.csv ${DOMAIN}"
             }
         }
         stage('Load > Calculate totals') {
             steps {
-              sh "echo '8121' > ${WORKING_DIR}/organization.id.txt"
-              sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/update_total_budget/run.rb '2018 2019' ${WORKING_DIR}/organization.id.txt"
+              sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/update_total_budget/run.rb '2018 2019 2020 2021' ${WORKING_DIR}/organization.id.txt"
             }
         }
         stage('Load > Calculate bubbles') {
@@ -95,7 +121,7 @@ pipeline {
         }
         stage('Load > Calculate annual data') {
             steps {
-              sh "cd ${GOBIERTO}; bin/rails runner ${GOBIERTO_ETL_UTILS}/operations/gobierto_budgets/annual_data/run.rb '2018 2019' ${WORKING_DIR}/organization.id.txt"
+              sh "cd ${GOBIERTO}; bin/rails runner ${GOBIERTO_ETL_UTILS}/operations/gobierto_budgets/annual_data/run.rb '2018 2019 2020 2021' ${WORKING_DIR}/organization.id.txt"
             }
         }
         stage('Load > Publish activity') {

--- a/pipelines/budgets/Jenkinsfile
+++ b/pipelines/budgets/Jenkinsfile
@@ -14,6 +14,7 @@ pipeline {
         stage('Clean working dir') {
           steps {
               sh "rm -rf ${WORKING_DIR}"
+              sh "mkdir -p ${WORKING_DIR}"
           }
         }
         stage('Create organization file') {

--- a/pipelines/budgets/Jenkinsfile
+++ b/pipelines/budgets/Jenkinsfile
@@ -74,6 +74,7 @@ pipeline {
             steps {
                 sh "cd ${MATARO_ETL}; ruby operations/gobierto_budgets/transform-executed/run.rb ${WORKING_DIR}/pressupost_2018_utf8_clean.csv ${WORKING_DIR}/budgets-executed-2018-transformed.json 2018"
                 sh "cd ${MATARO_ETL}; ruby operations/gobierto_budgets/transform-executed/run.rb ${WORKING_DIR}/pressupost_2019_utf8_clean.csv ${WORKING_DIR}/budgets-executed-2019-transformed.json 2019"
+                sh "cd ${MATARO_ETL}; ruby operations/gobierto_budgets/transform-executed/run.rb ${WORKING_DIR}/pressupost_2020_utf8_clean.csv ${WORKING_DIR}/budgets-executed-2020-transformed.json 2020"
             }
         }
         stage('Transform > Transform planned updated budgets data files') {
@@ -94,6 +95,7 @@ pipeline {
             steps {
                 sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/import-executed-budgets/run.rb ${WORKING_DIR}/budgets-executed-2018-transformed.json 2018"
                 sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/import-executed-budgets/run.rb ${WORKING_DIR}/budgets-executed-2019-transformed.json 2019"
+                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/import-executed-budgets/run.rb ${WORKING_DIR}/budgets-executed-2020-transformed.json 2020"
             }
         }
         stage('Load > Import planned updated budgets') {

--- a/pipelines/budgets/dev_run.sh
+++ b/pipelines/budgets/dev_run.sh
@@ -48,6 +48,7 @@ cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/transform-pla
 # Transform > Transform executed budgets data files
 cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/transform-executed/run.rb $WORKING_DIR/pressupost_2018_utf8_clean.csv $WORKING_DIR/budgets-executed-2018-transformed.json 2018
 cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/transform-executed/run.rb $WORKING_DIR/pressupost_2019_utf8_clean.csv $WORKING_DIR/budgets-executed-2019-transformed.json 2019
+cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/transform-executed/run.rb $WORKING_DIR/pressupost_2020_utf8_clean.csv $WORKING_DIR/budgets-executed-2020-transformed.json 2020
 
 # Transform > Transform planned updated data files
 cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/transform-planned-updated/run.rb $WORKING_DIR/pressupost_2018_utf8_clean.csv $WORKING_DIR/budgets-planned-updated-2018-transformed.json 2018
@@ -62,6 +63,7 @@ cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/import-planned
 # Load > Import executed budgets
 cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/import-executed-budgets/run.rb $WORKING_DIR/budgets-executed-2018-transformed.json 2018
 cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/import-executed-budgets/run.rb $WORKING_DIR/budgets-executed-2019-transformed.json 2019
+cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/import-executed-budgets/run.rb $WORKING_DIR/budgets-executed-2020-transformed.json 2020
 
 # Load > Import planned updated budgets
 cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/import-planned-budgets-updated/run.rb $WORKING_DIR/budgets-planned-updated-2018-transformed.json 2018

--- a/pipelines/budgets/dev_run.sh
+++ b/pipelines/budgets/dev_run.sh
@@ -9,10 +9,11 @@ MATARO_INE_CODE=8121
 rm -rf $WORKING_DIR
 mkdir $WORKING_DIR
 
-cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/clear-budgets/run.rb /Users/amiedes/Desktop/mataro_id.txt 2018
-cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/clear-budgets/run.rb /Users/amiedes/Desktop/mataro_id.txt 2019
-cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/clear-budgets/run.rb /Users/amiedes/Desktop/mataro_id.txt 2020
-cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/clear-budgets/run.rb /Users/amiedes/Desktop/mataro_id.txt 2021
+echo $MATARO_INE_CODE > $WORKING_DIR/mataro_id.txt
+cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/clear-budgets/run.rb $WORKING_DIR/mataro_id.txt 2018
+cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/clear-budgets/run.rb $WORKING_DIR/mataro_id.txt 2019
+cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/clear-budgets/run.rb $WORKING_DIR/mataro_id.txt 2020
+cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/clear-budgets/run.rb $WORKING_DIR/mataro_id.txt 2021
 
 # Extract > Download data sources
 cd $DEV_DIR/gobierto-etl-utils/; ruby operations/download/run.rb "http://dadesobertes.mataro.cat/pressupost_2018.csv" $WORKING_DIR/pressupost_2018.csv

--- a/pipelines/budgets/dev_run.sh
+++ b/pipelines/budgets/dev_run.sh
@@ -9,25 +9,40 @@ MATARO_INE_CODE=8121
 rm -rf $WORKING_DIR
 mkdir $WORKING_DIR
 
+cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/clear-budgets/run.rb /Users/amiedes/Desktop/mataro_id.txt 2018
+cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/clear-budgets/run.rb /Users/amiedes/Desktop/mataro_id.txt 2019
+cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/clear-budgets/run.rb /Users/amiedes/Desktop/mataro_id.txt 2020
+cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/clear-budgets/run.rb /Users/amiedes/Desktop/mataro_id.txt 2021
+
 # Extract > Download data sources
 cd $DEV_DIR/gobierto-etl-utils/; ruby operations/download/run.rb "http://dadesobertes.mataro.cat/pressupost_2018.csv" $WORKING_DIR/pressupost_2018.csv
 cd $DEV_DIR/gobierto-etl-utils/; ruby operations/download/run.rb "http://dadesobertes.mataro.cat/pressupost_2019.csv" $WORKING_DIR/pressupost_2019.csv
+cd $DEV_DIR/gobierto-etl-utils/; ruby operations/download/run.rb "https://dadesobertes.mataro.cat/pressupost_2020.csv" $WORKING_DIR/pressupost_2020.csv
+cd $DEV_DIR/gobierto-etl-utils/; ruby operations/download/run.rb "http://dadesobertes.mataro.cat/avant_pressupost_2020.csv" $WORKING_DIR/avant_pressupost_2020.csv
 
 # Extract > Convert data to UTF8
 cd $DEV_DIR/gobierto-etl-utils/; ruby operations/convert-to-utf8/run.rb $WORKING_DIR/pressupost_2018.csv $WORKING_DIR/pressupost_2018_utf8.csv ISO-8859-1
 cd $DEV_DIR/gobierto-etl-utils/; ruby operations/convert-to-utf8/run.rb $WORKING_DIR/pressupost_2019.csv $WORKING_DIR/pressupost_2019_utf8.csv ISO-8859-1
+cd $DEV_DIR/gobierto-etl-utils/; ruby operations/convert-to-utf8/run.rb $WORKING_DIR/pressupost_2020.csv $WORKING_DIR/pressupost_2020_utf8.csv ISO-8859-1
+cd $DEV_DIR/gobierto-etl-utils/; ruby operations/convert-to-utf8/run.rb $WORKING_DIR/avant_pressupost_2020.csv $WORKING_DIR/avant_pressupost_2020_utf8.csv ISO-8859-1
 
 # Extract > Clean wrong quotes
 cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/clean-quotes/run.rb $WORKING_DIR/pressupost_2018_utf8.csv $WORKING_DIR/pressupost_2018_utf8_clean.csv
 cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/clean-quotes/run.rb $WORKING_DIR/pressupost_2019_utf8.csv $WORKING_DIR/pressupost_2019_utf8_clean.csv
+cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/clean-quotes/run.rb $WORKING_DIR/pressupost_2020_utf8.csv $WORKING_DIR/pressupost_2020_utf8_clean.csv
+cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/clean-quotes/run.rb $WORKING_DIR/avant_pressupost_2020_utf8.csv $WORKING_DIR/avant_pressupost_2020_utf8_clean.csv
 
 # Extract > Check CSV format
 cd $DEV_DIR/gobierto-etl-utils/; ruby operations/check-csv/run.rb $WORKING_DIR/pressupost_2018_utf8_clean.csv
 cd $DEV_DIR/gobierto-etl-utils/; ruby operations/check-csv/run.rb $WORKING_DIR/pressupost_2019_utf8_clean.csv
+cd $DEV_DIR/gobierto-etl-utils/; ruby operations/check-csv/run.rb $WORKING_DIR/pressupost_2020_utf8_clean.csv
+cd $DEV_DIR/gobierto-etl-utils/; ruby operations/check-csv/run.rb $WORKING_DIR/avant_pressupost_2020_utf8_clean.csv
 
 # Transform > Transform planned budgets data files
 cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/transform-planned/run.rb $WORKING_DIR/pressupost_2018_utf8_clean.csv $WORKING_DIR/budgets-planned-2018-transformed.json 2018
 cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/transform-planned/run.rb $WORKING_DIR/pressupost_2019_utf8_clean.csv $WORKING_DIR/budgets-planned-2019-transformed.json 2019
+cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/transform-planned/run.rb $WORKING_DIR/pressupost_2020_utf8_clean.csv $WORKING_DIR/budgets-planned-2020-transformed.json 2020
+cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/transform-planned/run.rb $WORKING_DIR/avant_pressupost_2020_utf8_clean.csv $WORKING_DIR/budgets-planned-2021-transformed.json 2021
 
 # Transform > Transform executed budgets data files
 cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/transform-executed/run.rb $WORKING_DIR/pressupost_2018_utf8_clean.csv $WORKING_DIR/budgets-executed-2018-transformed.json 2018
@@ -40,6 +55,8 @@ cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/transform-pla
 # Load > Import planned budgets
 cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/import-planned-budgets/run.rb $WORKING_DIR/budgets-planned-2018-transformed.json 2018
 cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/import-planned-budgets/run.rb $WORKING_DIR/budgets-planned-2019-transformed.json 2019
+cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/import-planned-budgets/run.rb $WORKING_DIR/budgets-planned-2020-transformed.json 2020
+cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/import-planned-budgets/run.rb $WORKING_DIR/budgets-planned-2021-transformed.json 2021
 
 # Load > Import executed budgets
 cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/import-executed-budgets/run.rb $WORKING_DIR/budgets-executed-2018-transformed.json 2018
@@ -53,16 +70,18 @@ cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/import-planned
 cd $DEV_DIR/gobierto; bin/rails runner $DEV_DIR/gobierto-etl-mataro/operations/gobierto_budgets/extract-custom-categories/run.rb $WORKING_DIR/pressupost_2019_utf8_clean.csv mataro.gobierto.test
 cd $DEV_DIR/gobierto; bin/rails runner $DEV_DIR/gobierto-etl-mataro/operations/gobierto_budgets/extract-custom-categories/run.rb $WORKING_DIR/pressupost_2018_utf8_clean.csv mataro.gobierto.test
 cd $DEV_DIR/gobierto; bin/rails runner $DEV_DIR/gobierto-etl-mataro/operations/gobierto_budgets/extract-custom-categories/run.rb $WORKING_DIR/pressupost_2019_utf8_clean.csv mataro.gobierto.test
+cd $DEV_DIR/gobierto; bin/rails runner $DEV_DIR/gobierto-etl-mataro/operations/gobierto_budgets/extract-custom-categories/run.rb $WORKING_DIR/pressupost_2020_utf8_clean.csv mataro.gobierto.test
+cd $DEV_DIR/gobierto; bin/rails runner $DEV_DIR/gobierto-etl-mataro/operations/gobierto_budgets/extract-custom-categories/run.rb $WORKING_DIR/avant_pressupost_2020_utf8_clean.csv mataro.gobierto.test
 
 # Load > Calculate totals
 echo $MATARO_INE_CODE > $WORKING_DIR/organization.id.txt
-cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/update_total_budget/run.rb "2018 2019" $WORKING_DIR/organization.id.txt
+cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/update_total_budget/run.rb "2018 2019 2020 2021" $WORKING_DIR/organization.id.txt
 
 # Load > Calculate bubbles
 cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/bubbles/run.rb $WORKING_DIR/organization.id.txt
 
 # Load > Calculate annual data
-cd $DEV_DIR/gobierto/; bin/rails runner $DEV_DIR/gobierto-etl-utils/operations/gobierto_budgets/annual_data/run.rb "2018 2019" $WORKING_DIR/organization.id.txt
+cd $DEV_DIR/gobierto/; bin/rails runner $DEV_DIR/gobierto-etl-utils/operations/gobierto_budgets/annual_data/run.rb "2018 2019 2020 2021" $WORKING_DIR/organization.id.txt
 
 # Load > Publish activity
 cd $DEV_DIR/gobierto/; bin/rails runner $DEV_DIR/gobierto-etl-utils/operations/gobierto/publish-activity/run.rb budgets_updated $WORKING_DIR/organization.id.txt


### PR DESCRIPTION
- Loads pressupost_2020.csv as 2020 budgets
- Loads avant_prssupost_2020.csv as 2021 budgets to display it in elaboration (hack)
- Updates the CSV columns from where we read the budget lines values