### PR TITLE
1352 rename gobierto data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,6 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-gem "gobierto_data", git: "https://github.com/PopulateTools/gobierto_data.git"
+gem "gobierto_budgets_data", git: "https://github.com/PopulateTools/gobierto_budgets_data.git"
 gem "http"
 gem "byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
-  remote: https://github.com/PopulateTools/gobierto_data.git
-  revision: f5c5b1b0846ded63e034edcda2edee425d9d72bd
+  remote: https://github.com/PopulateTools/gobierto_budgets_data.git
+  revision: 17761ea394fdb07418ee89a751482da4c6ebdaaf
   specs:
-    gobierto_data (0.1.0)
+    gobierto_budgets_data (0.1.0)
       actionpack
       activesupport
       aws-sdk-s3
@@ -145,7 +145,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
-  gobierto_data!
+  gobierto_budgets_data!
   http
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ ETL scripts for Gobierto Mataró site: https://pressupost.mataro.cat/
 
 Edit `.env.example` and copy it to `.env` or `.rbenv-vars` with the expected values.
 
-This repository relies heavily in [gobierto_data](https://github.com/PopulateTools/gobierto_data)
+This repository relies heavily in [gobierto_budgets_data](https://github.com/PopulateTools/gobierto_budgets_data)
 
 ## Available operations
 

--- a/operations/gobierto_budgets/extract-custom-categories/run.rb
+++ b/operations/gobierto_budgets/extract-custom-categories/run.rb
@@ -51,16 +51,16 @@ def create_or_update_category!(name, code, kind)
 end
 
 FIRST_LEVEL_CUSTOM_CATEGORIES.each do |category_name, category_code|
-  GobiertoData::GobiertoBudgets::ALL_KINDS.each do |kind|
+  GobiertoBudgetsData::GobiertoBudgets::ALL_KINDS.each do |kind|
     create_or_update_category!(category_name, category_code, kind)
   end
 end
 
 CSV.read(input_file, headers: true).each do |row|
   if row['TIPPARTIDA'].strip == 'Despeses'
-    kind = GobiertoData::GobiertoBudgets::EXPENSE
+    kind = GobiertoBudgetsData::GobiertoBudgets::EXPENSE
   elsif row['TIPPARTIDA'].strip == 'Ingressos'
-    kind = GobiertoData::GobiertoBudgets::INCOME
+    kind = GobiertoBudgetsData::GobiertoBudgets::INCOME
   end
 
   level_2_category = row['PROGRAMA']

--- a/operations/gobierto_budgets/transform-executed/run.rb
+++ b/operations/gobierto_budgets/transform-executed/run.rb
@@ -35,7 +35,7 @@ year = ARGV[2].to_i
 puts "[START] transform-executed/run.rb with file=#{input_file} output=#{output_file} year=#{year}"
 
 place = INE::Places::Place.find_by_slug('mataro')
-population = GobiertoData::GobiertoBudgets::Population.get(place.id, year)
+population = GobiertoBudgetsData::GobiertoBudgets::Population.get(place.id, year)
 
 base_data = {
   organization_id: place.id,
@@ -53,10 +53,10 @@ def parse_cell(row, year, name, type)
 
   if row['TIPPARTIDA'].strip == 'Despeses'
     return if !['Obligaciones Reconocidas'].include?(row['DESACUM'].strip)
-    kind = GobiertoData::GobiertoBudgets::EXPENSE
+    kind = GobiertoBudgetsData::GobiertoBudgets::EXPENSE
   elsif row['TIPPARTIDA'].strip == 'Ingressos'
     return if !['Derechos Reconocidos Netos'].include?(row['DESACUM'].strip)
-    kind = GobiertoData::GobiertoBudgets::INCOME
+    kind = GobiertoBudgetsData::GobiertoBudgets::INCOME
   end
 
   category_name = row[name].strip
@@ -78,7 +78,7 @@ def parse_cell(row, year, name, type)
   end
 
   @categories[kind][category_code] ||= 0
-  if type == GobiertoData::GobiertoBudgets::CUSTOM_AREA_NAME
+  if type == GobiertoBudgetsData::GobiertoBudgets::CUSTOM_AREA_NAME
     @categories[kind][category_code] += row['IMPORTPRJPARTOTAL'].tr(',', '.').to_f
   else
     @categories[kind][category_code] += row['IMPORTPARTOTAL'].tr(',', '.').to_f
@@ -88,10 +88,10 @@ end
 
 ## Custom
 
-type = GobiertoData::GobiertoBudgets::CUSTOM_AREA_NAME
+type = GobiertoBudgetsData::GobiertoBudgets::CUSTOM_AREA_NAME
 
 @parent_categories = {}
-@categories = { GobiertoData::GobiertoBudgets::INCOME => {}, GobiertoData::GobiertoBudgets::EXPENSE => {} }
+@categories = { GobiertoBudgetsData::GobiertoBudgets::INCOME => {}, GobiertoBudgetsData::GobiertoBudgets::EXPENSE => {} }
 
 CSV.read(input_file, headers: true).each do |row|
   parse_cell(row, year, 'PROGRAMA', type)
@@ -141,9 +141,9 @@ end
 
 ## Economic
 
-type = GobiertoData::GobiertoBudgets::ECONOMIC_AREA_NAME
+type = GobiertoBudgetsData::GobiertoBudgets::ECONOMIC_AREA_NAME
 
-@categories = { GobiertoData::GobiertoBudgets::INCOME => {}, GobiertoData::GobiertoBudgets::EXPENSE => {} }
+@categories = { GobiertoBudgetsData::GobiertoBudgets::INCOME => {}, GobiertoBudgetsData::GobiertoBudgets::EXPENSE => {} }
 
 CSV.read(input_file, headers: true).each do |row|
   parse_cell(row, year, 'PARCAPITOL', type)
@@ -181,9 +181,9 @@ end
 
 ## Functional
 
-type = GobiertoData::GobiertoBudgets::FUNCTIONAL_AREA_NAME
+type = GobiertoBudgetsData::GobiertoBudgets::FUNCTIONAL_AREA_NAME
 
-@categories = { GobiertoData::GobiertoBudgets::INCOME => {}, GobiertoData::GobiertoBudgets::EXPENSE => {} }
+@categories = { GobiertoBudgetsData::GobiertoBudgets::INCOME => {}, GobiertoBudgetsData::GobiertoBudgets::EXPENSE => {} }
 
 
 CSV.read(input_file, headers: true).each do |row|
@@ -192,7 +192,7 @@ CSV.read(input_file, headers: true).each do |row|
   parse_cell(row, year, 'PARCLSFUN', type)
 end
 
-kind = GobiertoData::GobiertoBudgets::EXPENSE
+kind = GobiertoBudgetsData::GobiertoBudgets::EXPENSE
 @categories[kind].each do |code, amount|
   level = code.length
   next if level > 5

--- a/operations/gobierto_budgets/transform-planned-updated/run.rb
+++ b/operations/gobierto_budgets/transform-planned-updated/run.rb
@@ -35,7 +35,7 @@ year = ARGV[2].to_i
 puts "[START] transform-planned-updated/run.rb with file=#{input_file} output=#{output_file} year=#{year}"
 
 place = INE::Places::Place.find_by_slug('mataro')
-population = GobiertoData::GobiertoBudgets::Population.get(place.id, year)
+population = GobiertoBudgetsData::GobiertoBudgets::Population.get(place.id, year)
 
 base_data = {
   organization_id: place.id,
@@ -54,9 +54,9 @@ def parse_cell(row, year, name, type)
   return if !['Presupuesto Actual'].include?(row['DESACUM'].strip)
 
   if row['TIPPARTIDA'].strip == 'Despeses'
-    kind = GobiertoData::GobiertoBudgets::EXPENSE
+    kind = GobiertoBudgetsData::GobiertoBudgets::EXPENSE
   elsif row['TIPPARTIDA'].strip == 'Ingressos'
-    kind = GobiertoData::GobiertoBudgets::INCOME
+    kind = GobiertoBudgetsData::GobiertoBudgets::INCOME
   end
   category_name = row[name].strip
 
@@ -78,7 +78,7 @@ def parse_cell(row, year, name, type)
   end
 
   @categories[kind][category_code] ||= 0
-  if type == GobiertoData::GobiertoBudgets::CUSTOM_AREA_NAME
+  if type == GobiertoBudgetsData::GobiertoBudgets::CUSTOM_AREA_NAME
     @categories[kind][category_code] += row['IMPORTPRJPARDEFIN'].tr(',', '.').to_f
   else
     @categories[kind][category_code] += row['IMPORTPARDEFIN'].tr(',', '.').to_f
@@ -88,10 +88,10 @@ end
 
 ## Custom
 
-type = GobiertoData::GobiertoBudgets::CUSTOM_AREA_NAME
+type = GobiertoBudgetsData::GobiertoBudgets::CUSTOM_AREA_NAME
 
 @parent_categories = {}
-@categories = { GobiertoData::GobiertoBudgets::INCOME => {}, GobiertoData::GobiertoBudgets::EXPENSE => {} }
+@categories = { GobiertoBudgetsData::GobiertoBudgets::INCOME => {}, GobiertoBudgetsData::GobiertoBudgets::EXPENSE => {} }
 
 CSV.read(input_file, headers: true).each do |row|
   parse_cell(row, year, 'PROGRAMA', type)
@@ -141,9 +141,9 @@ end
 
 ## Economic
 
-type = GobiertoData::GobiertoBudgets::ECONOMIC_AREA_NAME
+type = GobiertoBudgetsData::GobiertoBudgets::ECONOMIC_AREA_NAME
 
-@categories = { GobiertoData::GobiertoBudgets::INCOME => {}, GobiertoData::GobiertoBudgets::EXPENSE => {} }
+@categories = { GobiertoBudgetsData::GobiertoBudgets::INCOME => {}, GobiertoBudgetsData::GobiertoBudgets::EXPENSE => {} }
 
 CSV.read(input_file, headers: true).each do |row|
   parse_cell(row, year, 'PARCAPITOL', type)
@@ -181,9 +181,9 @@ end
 
 ## Functional
 
-type = GobiertoData::GobiertoBudgets::FUNCTIONAL_AREA_NAME
+type = GobiertoBudgetsData::GobiertoBudgets::FUNCTIONAL_AREA_NAME
 
-@categories = { GobiertoData::GobiertoBudgets::INCOME => {}, GobiertoData::GobiertoBudgets::EXPENSE => {} }
+@categories = { GobiertoBudgetsData::GobiertoBudgets::INCOME => {}, GobiertoBudgetsData::GobiertoBudgets::EXPENSE => {} }
 
 CSV.read(input_file, headers: true).each do |row|
   parse_cell(row, year, 'PARCLSFUN_1D', type)
@@ -191,7 +191,7 @@ CSV.read(input_file, headers: true).each do |row|
   parse_cell(row, year, 'PARCLSFUN', type)
 end
 
-kind = GobiertoData::GobiertoBudgets::EXPENSE
+kind = GobiertoBudgetsData::GobiertoBudgets::EXPENSE
 @categories[kind].each do |code, amount|
   level = code.length
   next if level > 5

--- a/operations/gobierto_budgets/transform-planned/run.rb
+++ b/operations/gobierto_budgets/transform-planned/run.rb
@@ -35,7 +35,7 @@ year = ARGV[2].to_i
 puts "[START] transform-planned/run.rb with file=#{input_file} output=#{output_file} year=#{year}"
 
 place = INE::Places::Place.find_by_slug('mataro')
-population = GobiertoData::GobiertoBudgets::Population.get(place.id, year) || GobiertoData::GobiertoBudgets::Population.get(place.id, year - 1)
+population = GobiertoBudgetsData::GobiertoBudgets::Population.get(place.id, year) || GobiertoBudgetsData::GobiertoBudgets::Population.get(place.id, year - 1)
 
 base_data = {
   organization_id: place.id,
@@ -62,9 +62,9 @@ def parse_cell(row, year, name)
   category_name = row[name].strip
 
   if row['TIPPARTIDA'].strip == 'Despeses'
-    kind = GobiertoData::GobiertoBudgets::EXPENSE
+    kind = GobiertoBudgetsData::GobiertoBudgets::EXPENSE
   elsif row['TIPPARTIDA'].strip == 'Ingressos'
-    kind = GobiertoData::GobiertoBudgets::INCOME
+    kind = GobiertoBudgetsData::GobiertoBudgets::INCOME
   end
   re = /\A([I\d\-]+)\-(.+)\z/
   if category_name !~ re
@@ -99,11 +99,11 @@ end
 
 ## Custom
 
-type = GobiertoData::GobiertoBudgets::CUSTOM_AREA_NAME
+type = GobiertoBudgetsData::GobiertoBudgets::CUSTOM_AREA_NAME
 
 @parent_categories = {}
-@categories = { GobiertoData::GobiertoBudgets::INCOME => {}, GobiertoData::GobiertoBudgets::EXPENSE => {} }
-@economic_categories = { GobiertoData::GobiertoBudgets::INCOME => {}, GobiertoData::GobiertoBudgets::EXPENSE => {} }
+@categories = { GobiertoBudgetsData::GobiertoBudgets::INCOME => {}, GobiertoBudgetsData::GobiertoBudgets::EXPENSE => {} }
+@economic_categories = { GobiertoBudgetsData::GobiertoBudgets::INCOME => {}, GobiertoBudgetsData::GobiertoBudgets::EXPENSE => {} }
 
 CSV.read(input_file, headers: true).each do |row|
   parse_cell(row, year, 'PROGRAMA')
@@ -172,9 +172,9 @@ end
 
 ## Economic
 
-type = GobiertoData::GobiertoBudgets::ECONOMIC_AREA_NAME
+type = GobiertoBudgetsData::GobiertoBudgets::ECONOMIC_AREA_NAME
 
-@categories = { GobiertoData::GobiertoBudgets::INCOME => {}, GobiertoData::GobiertoBudgets::EXPENSE => {} }
+@categories = { GobiertoBudgetsData::GobiertoBudgets::INCOME => {}, GobiertoBudgetsData::GobiertoBudgets::EXPENSE => {} }
 
 CSV.read(input_file, headers: true).each do |row|
   parse_cell(row, year, 'PARCAPITOL')
@@ -212,10 +212,10 @@ end
 
 ## Functional
 
-type = GobiertoData::GobiertoBudgets::FUNCTIONAL_AREA_NAME
+type = GobiertoBudgetsData::GobiertoBudgets::FUNCTIONAL_AREA_NAME
 
-@categories = { GobiertoData::GobiertoBudgets::INCOME => {}, GobiertoData::GobiertoBudgets::EXPENSE => {} }
-@economic_categories = { GobiertoData::GobiertoBudgets::INCOME => {}, GobiertoData::GobiertoBudgets::EXPENSE => {} }
+@categories = { GobiertoBudgetsData::GobiertoBudgets::INCOME => {}, GobiertoBudgetsData::GobiertoBudgets::EXPENSE => {} }
+@economic_categories = { GobiertoBudgetsData::GobiertoBudgets::INCOME => {}, GobiertoBudgetsData::GobiertoBudgets::EXPENSE => {} }
 
 
 CSV.read(input_file, headers: true).each do |row|
@@ -224,7 +224,7 @@ CSV.read(input_file, headers: true).each do |row|
   parse_cell(row, year, 'PARCLSFUN')
 end
 
-kind = GobiertoData::GobiertoBudgets::EXPENSE
+kind = GobiertoBudgetsData::GobiertoBudgets::EXPENSE
 @categories[kind].each do |code, amount|
   level = code.length
   next if level > 5


### PR DESCRIPTION
Related to PopulateTools/issues#1352

This PR replaces namespaces of `GobiertoData` with `GobiertoBudgetsData` and updates the gems dependency to point `gobierto_budgets_data` instead of `gobierto_data`