### PR TITLE
Use clear-cache operation including site and namespace

### DIFF
--- a/pipelines/budgets/Jenkinsfile
+++ b/pipelines/budgets/Jenkinsfile
@@ -6,6 +6,7 @@ pipeline {
         GOBIERTO_ETL_UTILS = "/var/www/gobierto-etl-utils/current/"
         MATARO_ETL = "/var/www/gobierto-etl-mataro/current/"
         WORKING_DIR = "/tmp/mataro_budgets"
+        MATARO_ID = "8121"
         // Variables that must be defined via Jenkins UI:
         // GOBIERTO = "/var/www/gobierto/current"
         // DOMAIN = "pressupost.mataro.cat"
@@ -22,7 +23,7 @@ pipeline {
         }
         stage('Create organization file') {
             steps {
-              sh "echo '8121' > ${WORKING_DIR}/organization.id.txt"
+              sh "echo '${MATARO_ID}' > ${WORKING_DIR}/organization.id.txt"
             }
         }
         stage('Extract > Download data sources') {
@@ -115,7 +116,7 @@ pipeline {
         }
         stage('Clear cache') {
           steps {
-            sh "cd ${GOBIERTO}; bin/rails runner ${GOBIERTO_ETL_UTILS}/operations/gobierto/clear-cache/run.rb"
+            sh "cd ${GOBIERTO}; bin/rails runner ${GOBIERTO_ETL_UTILS}/operations/gobierto/clear-cache/run.rb --site-organization-id '${MATARO_ID}' --namespace 'GobiertoBudgets'"
           }
         }
     }

--- a/pipelines/budgets/dev_run.sh
+++ b/pipelines/budgets/dev_run.sh
@@ -71,4 +71,4 @@ cd $DEV_DIR/gobierto/; bin/rails runner $DEV_DIR/gobierto-etl-utils/operations/g
 cd $DEV_DIR/gobierto/; bin/rails runner $DEV_DIR/gobierto-etl-utils/operations/gobierto/publish-activity/run.rb budgets_updated $WORKING_DIR/organization.id.txt
 
 # Clear cache
-cd $DEV_DIR/gobierto/; bin/rails runner $DEV_DIR/gobierto-etl-utils/operations/gobierto/clear-cache/run.rb
+cd $DEV_DIR/gobierto/; bin/rails runner $DEV_DIR/gobierto-etl-utils/operations/gobierto/clear-cache/run.rb --site-organization-id "$MATARO_INE_CODE" --namespace "GobiertoBudgets"

--- a/pipelines/investments_projects/Jenkinsfile
+++ b/pipelines/investments_projects/Jenkinsfile
@@ -65,7 +65,7 @@ pipeline {
         }
         stage('Clear cache') {
             steps {
-                sh "cd ${GOBIERTO}; bin/rails runner ${GOBIERTO_ETL_UTILS}/operations/gobierto/clear-cache/run.rb"
+                sh "cd ${GOBIERTO}; bin/rails runner ${GOBIERTO_ETL_UTILS}/operations/gobierto/clear-cache/run.rb --site-organization-id '${MATARO_ID}' --namespace 'GobiertoInvestments'"
             }
         }
     }


### PR DESCRIPTION
Related to PopulateTools/issues#1439

This PR replaces the clear-cache operation call and includes site and namespace arguments