### PR TITLE
2022 executed and planned updated budget data

### DIFF
--- a/pipelines/budgets/Jenkinsfile
+++ b/pipelines/budgets/Jenkinsfile
@@ -59,11 +59,13 @@ pipeline {
         stage('Transform > Transform executed budgets data files') {
             steps {
                 sh "cd ${MATARO_ETL}; ruby operations/gobierto_budgets/transform-executed/run.rb ${WORKING_DIR}/pressupost_2021_utf8_clean.csv ${WORKING_DIR}/budgets-executed-2021-transformed.json 2021"
+                sh "cd ${MATARO_ETL}; ruby operations/gobierto_budgets/transform-executed/run.rb ${WORKING_DIR}/pressupost_2022_utf8_clean.csv ${WORKING_DIR}/budgets-executed-2022-transformed.json 2022"
             }
         }
         stage('Transform > Transform planned updated budgets data files') {
             steps {
                 sh "cd ${MATARO_ETL}; ruby operations/gobierto_budgets/transform-planned-updated/run.rb ${WORKING_DIR}/pressupost_2021_utf8_clean.csv ${WORKING_DIR}/budgets-planned-updated-2021-transformed.json 2021"
+                sh "cd ${MATARO_ETL}; ruby operations/gobierto_budgets/transform-planned-updated/run.rb ${WORKING_DIR}/pressupost_2022_utf8_clean.csv ${WORKING_DIR}/budgets-planned-updated-2022-transformed.json 2022"
             }
         }
         stage('Load > Clear previous data') {
@@ -81,11 +83,13 @@ pipeline {
         stage('Load > Import executed budgets') {
             steps {
                 sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/import-executed-budgets/run.rb ${WORKING_DIR}/budgets-executed-2021-transformed.json 2021"
+                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/import-executed-budgets/run.rb ${WORKING_DIR}/budgets-executed-2022-transformed.json 2022"
             }
         }
         stage('Load > Import planned updated budgets') {
             steps {
                 sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/import-planned-budgets-updated/run.rb ${WORKING_DIR}/budgets-planned-updated-2021-transformed.json 2021"
+                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/import-planned-budgets-updated/run.rb ${WORKING_DIR}/budgets-planned-updated-2022-transformed.json 2022"
             }
         }
         stage('Load > Import custom categories') {

--- a/pipelines/budgets/dev_run.sh
+++ b/pipelines/budgets/dev_run.sh
@@ -35,9 +35,11 @@ cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/transform-pla
 
 # Transform > Transform executed budgets data files
 cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/transform-executed/run.rb $WORKING_DIR/pressupost_2021_utf8_clean.csv $WORKING_DIR/budgets-executed-2021-transformed.json 2021
+cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/transform-executed/run.rb $WORKING_DIR/pressupost_2022_utf8_clean.csv $WORKING_DIR/budgets-executed-2022-transformed.json 2022
 
 # Transform > Transform planned updated data files
 cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/transform-planned-updated/run.rb $WORKING_DIR/pressupost_2021_utf8_clean.csv $WORKING_DIR/budgets-planned-updated-2021-transformed.json 2021
+cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/transform-planned-updated/run.rb $WORKING_DIR/pressupost_2022_utf8_clean.csv $WORKING_DIR/budgets-planned-updated-2022-transformed.json 2022
 
 # Load > Clear existing budgets
 cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/clear-budgets/run.rb $WORKING_DIR/mataro_id.txt 2021
@@ -49,9 +51,11 @@ cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/import-planned
 
 # Load > Import executed budgets
 cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/import-executed-budgets/run.rb $WORKING_DIR/budgets-executed-2021-transformed.json 2021
+cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/import-executed-budgets/run.rb $WORKING_DIR/budgets-executed-2022-transformed.json 2022
 
 # Load > Import planned updated budgets
 cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/import-planned-budgets-updated/run.rb $WORKING_DIR/budgets-planned-updated-2021-transformed.json 2021
+cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/import-planned-budgets-updated/run.rb $WORKING_DIR/budgets-planned-updated-2022-transformed.json 2022
 
 # Load > Import custom categories
 cd $DEV_DIR/gobierto; bin/rails runner $DEV_DIR/gobierto-etl-mataro/operations/gobierto_budgets/extract-custom-categories/run.rb $WORKING_DIR/pressupost_2021_utf8_clean.csv $1

--- a/pipelines/budgets/dev_run.sh
+++ b/pipelines/budgets/dev_run.sh
@@ -31,7 +31,7 @@ cd $DEV_DIR/gobierto-etl-utils/; ruby operations/check-csv/run.rb $WORKING_DIR/p
 
 # Transform > Transform planned budgets data files
 cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/transform-planned/run.rb $WORKING_DIR/pressupost_2021_utf8_clean.csv $WORKING_DIR/budgets-planned-2021-transformed.json 2021
-cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/transform-planned/run.rb $WORKING_DIR/pressupost_2022_utf8_clean.csv $WORKING_DIR/budgets-planned-2022-transformed.json 2021
+cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/transform-planned/run.rb $WORKING_DIR/pressupost_2022_utf8_clean.csv $WORKING_DIR/budgets-planned-2022-transformed.json 2022
 
 # Transform > Transform executed budgets data files
 cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/transform-executed/run.rb $WORKING_DIR/pressupost_2021_utf8_clean.csv $WORKING_DIR/budgets-executed-2021-transformed.json 2021


### PR DESCRIPTION
Related to: PopulateTools/issues#1491

This PR:

* Fixes year on local dev transform operation of 2022 budgets
* Adds transform and load operations of executed and planned upated budget data of 2022

Note: I've downloaded and transformed the data locally and it seems that currently there are no data of executed and planned updated data on 2022 CSV file, so I keep the branch without merging into staging for now