### PR TITLE
Load 2023 data

### DIFF
--- a/operations/gobierto_budgets/transform-executed/run.rb
+++ b/operations/gobierto_budgets/transform-executed/run.rb
@@ -124,6 +124,8 @@ end
       parent_code = code[0..4]
     end
 
+    next if level >= 4
+
     output_data.push base_data.merge({
       amount: amount.to_f.round(2),
       code: code,
@@ -166,6 +168,7 @@ end
 
     next if @categories[kind].select{|l| l.starts_with?(parent_code) && l != parent_code && l != code }.empty?
     next if amount == 0
+    next if level >= 4
 
     output_data.push base_data.merge({
       amount: amount.to_f.round(2),
@@ -205,6 +208,7 @@ kind = GobiertoBudgetsData::GobiertoBudgets::EXPENSE
 
   next if @categories[kind].select{|l| l.starts_with?(parent_code) && l != parent_code && l != code }.empty?
   next if amount == 0
+  next if level >= 4
 
   output_data.push base_data.merge({
     amount: amount.to_f.round(2),

--- a/operations/gobierto_budgets/transform-planned-updated/run.rb
+++ b/operations/gobierto_budgets/transform-planned-updated/run.rb
@@ -124,6 +124,8 @@ end
       parent_code = code[0..4]
     end
 
+    next if level >= 4
+
     output_data.push base_data.merge({
       amount: amount.to_f.round(2),
       code: code,
@@ -166,6 +168,7 @@ end
 
     next if @categories[kind].select{|l| l.starts_with?(parent_code) && l != parent_code && l != code }.empty?
     next if amount == 0
+    next if level >= 4
 
     output_data.push base_data.merge({
       amount: amount.to_f.round(2),
@@ -204,6 +207,7 @@ kind = GobiertoBudgetsData::GobiertoBudgets::EXPENSE
 
   next if @categories[kind].select{|l| l.starts_with?(parent_code) && l != parent_code && l != code }.empty?
   next if amount == 0
+  next if level >= 4
 
   output_data.push base_data.merge({
     amount: amount.to_f.round(2),

--- a/operations/gobierto_budgets/transform-planned/run.rb
+++ b/operations/gobierto_budgets/transform-planned/run.rb
@@ -140,6 +140,8 @@ end
       parent_code = code[0..4]
     end
 
+    next if level >= 4
+
     output_data.push base_data.merge({
       amount: amount.to_f.round(2),
       code: code,
@@ -201,6 +203,7 @@ end
 
     next if @categories[kind].select{|l| l.starts_with?(parent_code) && l != parent_code && l != code }.empty?
     next if amount == 0
+    next if level >= 4
 
     output_data.push base_data.merge({
       amount: amount.to_f.round(2),
@@ -241,6 +244,7 @@ kind = GobiertoBudgetsData::GobiertoBudgets::EXPENSE
 
   next if @categories[kind].select{|l| l.starts_with?(parent_code) && l != parent_code && l != code }.empty?
   next if amount == 0
+  next if level >= 4
 
   output_data.push base_data.merge({
     amount: amount.to_f.round(2),

--- a/operations/gobierto_budgets/transform-planned/run.rb
+++ b/operations/gobierto_budgets/transform-planned/run.rb
@@ -49,7 +49,7 @@ base_data = {
 output_data = []
 
 def parse_amount(row, year)
-  cell_value = if year == 2022
+  cell_value = if year == 2023
                  row["IMPASSIG_V3"]
                else
                  row["IMPASSIG_V1"]

--- a/operations/gobierto_budgets/transform-planned/run.rb
+++ b/operations/gobierto_budgets/transform-planned/run.rb
@@ -61,9 +61,8 @@ def parse_amount(row, year)
 end
 
 def parse_cell(row, year, name)
-  return if year == 2021 && (row["IMPASSIG_V3"].blank? || !row["CODIACUM"].blank?)
-  return if year == 2020 && (row["IMPASSIG_V4"].blank? || !row["CODIACUM"].blank?)
-  return if year != 2020 && row["IMPASSIG_V1"].blank?
+  return if year == 2023 && (row["IMPASSIG_V3"].blank? || !row["CODIACUM"].blank?)
+  return if year == 2022 && row["IMPASSIG_V1"].blank?
   return if row[name].blank?
 
   category_name = row[name].strip

--- a/operations/gobierto_budgets/transform-planned/run.rb
+++ b/operations/gobierto_budgets/transform-planned/run.rb
@@ -49,10 +49,8 @@ base_data = {
 output_data = []
 
 def parse_amount(row, year)
-  cell_value = if year == 2021
+  cell_value = if year == 2022
                  row["IMPASSIG_V3"]
-               elsif year == 2020
-                 row["IMPASSIG_V4"]
                else
                  row["IMPASSIG_V1"]
                end

--- a/pipelines/budgets/Jenkinsfile
+++ b/pipelines/budgets/Jenkinsfile
@@ -28,79 +28,79 @@ pipeline {
         }
         stage('Extract > Download data sources') {
             steps {
-                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/download/run.rb 'http://dadesobertes.mataro.cat/pressupost_2021.csv' ${WORKING_DIR}/pressupost_2021.csv"
+                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/download/run.rb 'http://dadesobertes.mataro.cat/pressupost_2023.csv' ${WORKING_DIR}/pressupost_2023.csv"
                 sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/download/run.rb 'http://dadesobertes.mataro.cat/pressupost_2022.csv' ${WORKING_DIR}/pressupost_2022.csv"
             }
         }
         stage('Extract > Convert data to UTF8') {
             steps {
-                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/convert-to-utf8/run.rb ${WORKING_DIR}/pressupost_2021.csv ${WORKING_DIR}/pressupost_2021_utf8.csv ISO-8859-1"
+                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/convert-to-utf8/run.rb ${WORKING_DIR}/pressupost_2023.csv ${WORKING_DIR}/pressupost_2023_utf8.csv ISO-8859-1"
                 sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/convert-to-utf8/run.rb ${WORKING_DIR}/pressupost_2022.csv ${WORKING_DIR}/pressupost_2022_utf8.csv ISO-8859-1"
             }
         }
         stage('Extract > Clean wrong quotes') {
             steps {
-                sh "cd ${MATARO_ETL}; ruby operations/gobierto_budgets/clean-quotes/run.rb ${WORKING_DIR}/pressupost_2021_utf8.csv ${WORKING_DIR}/pressupost_2021_utf8_clean.csv"
+                sh "cd ${MATARO_ETL}; ruby operations/gobierto_budgets/clean-quotes/run.rb ${WORKING_DIR}/pressupost_2023_utf8.csv ${WORKING_DIR}/pressupost_2023_utf8_clean.csv"
                 sh "cd ${MATARO_ETL}; ruby operations/gobierto_budgets/clean-quotes/run.rb ${WORKING_DIR}/pressupost_2022_utf8.csv ${WORKING_DIR}/pressupost_2022_utf8_clean.csv"
             }
         }
         stage('Extract > Check CSV format') {
             steps {
-                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/check-csv/run.rb ${WORKING_DIR}/pressupost_2021_utf8_clean.csv"
+                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/check-csv/run.rb ${WORKING_DIR}/pressupost_2023_utf8_clean.csv"
                 sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/check-csv/run.rb ${WORKING_DIR}/pressupost_2022_utf8_clean.csv"
             }
         }
         stage('Transform > Transform planned budgets data files') {
             steps {
-                sh "cd ${MATARO_ETL}; ruby operations/gobierto_budgets/transform-planned/run.rb ${WORKING_DIR}/pressupost_2021_utf8_clean.csv ${WORKING_DIR}/budgets-planned-2021-transformed.json 2021"
+                sh "cd ${MATARO_ETL}; ruby operations/gobierto_budgets/transform-planned/run.rb ${WORKING_DIR}/pressupost_2023_utf8_clean.csv ${WORKING_DIR}/budgets-planned-2023-transformed.json 2023"
                 sh "cd ${MATARO_ETL}; ruby operations/gobierto_budgets/transform-planned/run.rb ${WORKING_DIR}/pressupost_2022_utf8_clean.csv ${WORKING_DIR}/budgets-planned-2022-transformed.json 2022"
             }
         }
         stage('Transform > Transform executed budgets data files') {
             steps {
-                sh "cd ${MATARO_ETL}; ruby operations/gobierto_budgets/transform-executed/run.rb ${WORKING_DIR}/pressupost_2021_utf8_clean.csv ${WORKING_DIR}/budgets-executed-2021-transformed.json 2021"
+                sh "cd ${MATARO_ETL}; ruby operations/gobierto_budgets/transform-executed/run.rb ${WORKING_DIR}/pressupost_2023_utf8_clean.csv ${WORKING_DIR}/budgets-executed-2023-transformed.json 2023"
                 sh "cd ${MATARO_ETL}; ruby operations/gobierto_budgets/transform-executed/run.rb ${WORKING_DIR}/pressupost_2022_utf8_clean.csv ${WORKING_DIR}/budgets-executed-2022-transformed.json 2022"
             }
         }
         stage('Transform > Transform planned updated budgets data files') {
             steps {
-                sh "cd ${MATARO_ETL}; ruby operations/gobierto_budgets/transform-planned-updated/run.rb ${WORKING_DIR}/pressupost_2021_utf8_clean.csv ${WORKING_DIR}/budgets-planned-updated-2021-transformed.json 2021"
+                sh "cd ${MATARO_ETL}; ruby operations/gobierto_budgets/transform-planned-updated/run.rb ${WORKING_DIR}/pressupost_2023_utf8_clean.csv ${WORKING_DIR}/budgets-planned-updated-2023-transformed.json 2023"
                 sh "cd ${MATARO_ETL}; ruby operations/gobierto_budgets/transform-planned-updated/run.rb ${WORKING_DIR}/pressupost_2022_utf8_clean.csv ${WORKING_DIR}/budgets-planned-updated-2022-transformed.json 2022"
             }
         }
         stage('Load > Clear previous data') {
             steps {
-              sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/clear-budgets/run.rb ${WORKING_DIR}/organization.id.txt 2021"
+              sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/clear-budgets/run.rb ${WORKING_DIR}/organization.id.txt 2023"
               sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/clear-budgets/run.rb ${WORKING_DIR}/organization.id.txt 2022"
             }
         }
         stage('Load > Import planned budgets') {
             steps {
-                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/import-planned-budgets/run.rb ${WORKING_DIR}/budgets-planned-2021-transformed.json 2021"
+                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/import-planned-budgets/run.rb ${WORKING_DIR}/budgets-planned-2023-transformed.json 2023"
                 sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/import-planned-budgets/run.rb ${WORKING_DIR}/budgets-planned-2022-transformed.json 2022"
             }
         }
         stage('Load > Import executed budgets') {
             steps {
-                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/import-executed-budgets/run.rb ${WORKING_DIR}/budgets-executed-2021-transformed.json 2021"
+                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/import-executed-budgets/run.rb ${WORKING_DIR}/budgets-executed-2023-transformed.json 2023"
                 sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/import-executed-budgets/run.rb ${WORKING_DIR}/budgets-executed-2022-transformed.json 2022"
             }
         }
         stage('Load > Import planned updated budgets') {
             steps {
-                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/import-planned-budgets-updated/run.rb ${WORKING_DIR}/budgets-planned-updated-2021-transformed.json 2021"
+                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/import-planned-budgets-updated/run.rb ${WORKING_DIR}/budgets-planned-updated-2023-transformed.json 2023"
                 sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/import-planned-budgets-updated/run.rb ${WORKING_DIR}/budgets-planned-updated-2022-transformed.json 2022"
             }
         }
         stage('Load > Import custom categories') {
             steps {
-                sh "cd ${GOBIERTO}; bin/rails runner ${MATARO_ETL}/operations/gobierto_budgets/extract-custom-categories/run.rb ${WORKING_DIR}/pressupost_2021_utf8_clean.csv ${DOMAIN}"
+                sh "cd ${GOBIERTO}; bin/rails runner ${MATARO_ETL}/operations/gobierto_budgets/extract-custom-categories/run.rb ${WORKING_DIR}/pressupost_2023_utf8_clean.csv ${DOMAIN}"
                 sh "cd ${GOBIERTO}; bin/rails runner ${MATARO_ETL}/operations/gobierto_budgets/extract-custom-categories/run.rb ${WORKING_DIR}/pressupost_2022_utf8_clean.csv ${DOMAIN}"
             }
         }
         stage('Load > Calculate totals') {
             steps {
-              sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/update_total_budget/run.rb '2021 2022' ${WORKING_DIR}/organization.id.txt"
+              sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/gobierto_budgets/update_total_budget/run.rb '2023 2022' ${WORKING_DIR}/organization.id.txt"
             }
         }
         stage('Load > Calculate bubbles') {
@@ -110,7 +110,7 @@ pipeline {
         }
         stage('Load > Calculate annual data') {
             steps {
-              sh "cd ${GOBIERTO}; bin/rails runner ${GOBIERTO_ETL_UTILS}/operations/gobierto_budgets/annual_data/run.rb '2021 2022' ${WORKING_DIR}/organization.id.txt"
+              sh "cd ${GOBIERTO}; bin/rails runner ${GOBIERTO_ETL_UTILS}/operations/gobierto_budgets/annual_data/run.rb '2023 2022' ${WORKING_DIR}/organization.id.txt"
             }
         }
         stage('Load > Publish activity') {

--- a/pipelines/budgets/dev_run.sh
+++ b/pipelines/budgets/dev_run.sh
@@ -14,62 +14,62 @@ mkdir $WORKING_DIR
 echo $MATARO_INE_CODE > $WORKING_DIR/mataro_id.txt
 
 # Extract > Download data sources
-cd $DEV_DIR/gobierto-etl-utils/; ruby operations/download/run.rb "https://dadesobertes.mataro.cat/pressupost_2021.csv" $WORKING_DIR/pressupost_2021.csv
+cd $DEV_DIR/gobierto-etl-utils/; ruby operations/download/run.rb "https://dadesobertes.mataro.cat/pressupost_2023.csv" $WORKING_DIR/pressupost_2023.csv
 cd $DEV_DIR/gobierto-etl-utils/; ruby operations/download/run.rb "https://dadesobertes.mataro.cat/pressupost_2022.csv" $WORKING_DIR/pressupost_2022.csv
 
 # Extract > Convert data to UTF8
-cd $DEV_DIR/gobierto-etl-utils/; ruby operations/convert-to-utf8/run.rb $WORKING_DIR/pressupost_2021.csv $WORKING_DIR/pressupost_2021_utf8.csv ISO-8859-1
+cd $DEV_DIR/gobierto-etl-utils/; ruby operations/convert-to-utf8/run.rb $WORKING_DIR/pressupost_2023.csv $WORKING_DIR/pressupost_2023_utf8.csv ISO-8859-1
 cd $DEV_DIR/gobierto-etl-utils/; ruby operations/convert-to-utf8/run.rb $WORKING_DIR/pressupost_2022.csv $WORKING_DIR/pressupost_2022_utf8.csv ISO-8859-1
 
 # Extract > Clean wrong quotes
-cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/clean-quotes/run.rb $WORKING_DIR/pressupost_2021_utf8.csv $WORKING_DIR/pressupost_2021_utf8_clean.csv
+cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/clean-quotes/run.rb $WORKING_DIR/pressupost_2023_utf8.csv $WORKING_DIR/pressupost_2023_utf8_clean.csv
 cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/clean-quotes/run.rb $WORKING_DIR/pressupost_2022_utf8.csv $WORKING_DIR/pressupost_2022_utf8_clean.csv
 
 # Extract > Check CSV format
-cd $DEV_DIR/gobierto-etl-utils/; ruby operations/check-csv/run.rb $WORKING_DIR/pressupost_2021_utf8_clean.csv
+cd $DEV_DIR/gobierto-etl-utils/; ruby operations/check-csv/run.rb $WORKING_DIR/pressupost_2023_utf8_clean.csv
 cd $DEV_DIR/gobierto-etl-utils/; ruby operations/check-csv/run.rb $WORKING_DIR/pressupost_2022_utf8_clean.csv
 
 # Transform > Transform planned budgets data files
-cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/transform-planned/run.rb $WORKING_DIR/pressupost_2021_utf8_clean.csv $WORKING_DIR/budgets-planned-2021-transformed.json 2021
+cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/transform-planned/run.rb $WORKING_DIR/pressupost_2023_utf8_clean.csv $WORKING_DIR/budgets-planned-2023-transformed.json 2023
 cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/transform-planned/run.rb $WORKING_DIR/pressupost_2022_utf8_clean.csv $WORKING_DIR/budgets-planned-2022-transformed.json 2022
 
 # Transform > Transform executed budgets data files
-cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/transform-executed/run.rb $WORKING_DIR/pressupost_2021_utf8_clean.csv $WORKING_DIR/budgets-executed-2021-transformed.json 2021
+cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/transform-executed/run.rb $WORKING_DIR/pressupost_2023_utf8_clean.csv $WORKING_DIR/budgets-executed-2023-transformed.json 2023
 cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/transform-executed/run.rb $WORKING_DIR/pressupost_2022_utf8_clean.csv $WORKING_DIR/budgets-executed-2022-transformed.json 2022
 
 # Transform > Transform planned updated data files
-cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/transform-planned-updated/run.rb $WORKING_DIR/pressupost_2021_utf8_clean.csv $WORKING_DIR/budgets-planned-updated-2021-transformed.json 2021
+cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/transform-planned-updated/run.rb $WORKING_DIR/pressupost_2023_utf8_clean.csv $WORKING_DIR/budgets-planned-updated-2023-transformed.json 2023
 cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_budgets/transform-planned-updated/run.rb $WORKING_DIR/pressupost_2022_utf8_clean.csv $WORKING_DIR/budgets-planned-updated-2022-transformed.json 2022
 
 # Load > Clear existing budgets
-cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/clear-budgets/run.rb $WORKING_DIR/mataro_id.txt 2021
+cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/clear-budgets/run.rb $WORKING_DIR/mataro_id.txt 2023
 cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/clear-budgets/run.rb $WORKING_DIR/mataro_id.txt 2022
 
 # Load > Import planned budgets
-cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/import-planned-budgets/run.rb $WORKING_DIR/budgets-planned-2021-transformed.json 2021
+cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/import-planned-budgets/run.rb $WORKING_DIR/budgets-planned-2023-transformed.json 2023
 cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/import-planned-budgets/run.rb $WORKING_DIR/budgets-planned-2022-transformed.json 2022
 
 # Load > Import executed budgets
-cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/import-executed-budgets/run.rb $WORKING_DIR/budgets-executed-2021-transformed.json 2021
+cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/import-executed-budgets/run.rb $WORKING_DIR/budgets-executed-2023-transformed.json 2023
 cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/import-executed-budgets/run.rb $WORKING_DIR/budgets-executed-2022-transformed.json 2022
 
 # Load > Import planned updated budgets
-cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/import-planned-budgets-updated/run.rb $WORKING_DIR/budgets-planned-updated-2021-transformed.json 2021
+cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/import-planned-budgets-updated/run.rb $WORKING_DIR/budgets-planned-updated-2023-transformed.json 2023
 cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/import-planned-budgets-updated/run.rb $WORKING_DIR/budgets-planned-updated-2022-transformed.json 2022
 
 # Load > Import custom categories
-cd $DEV_DIR/gobierto; bin/rails runner $DEV_DIR/gobierto-etl-mataro/operations/gobierto_budgets/extract-custom-categories/run.rb $WORKING_DIR/pressupost_2021_utf8_clean.csv $1
+cd $DEV_DIR/gobierto; bin/rails runner $DEV_DIR/gobierto-etl-mataro/operations/gobierto_budgets/extract-custom-categories/run.rb $WORKING_DIR/pressupost_2023_utf8_clean.csv $1
 cd $DEV_DIR/gobierto; bin/rails runner $DEV_DIR/gobierto-etl-mataro/operations/gobierto_budgets/extract-custom-categories/run.rb $WORKING_DIR/pressupost_2022_utf8_clean.csv $1
 
 # Load > Calculate totals
 echo $MATARO_INE_CODE > $WORKING_DIR/organization.id.txt
-cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/update_total_budget/run.rb "2021 2022" $WORKING_DIR/organization.id.txt
+cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/update_total_budget/run.rb "2023 2022" $WORKING_DIR/organization.id.txt
 
 # Load > Calculate bubbles
 cd $DEV_DIR/gobierto-etl-utils/; ruby operations/gobierto_budgets/bubbles/run.rb $WORKING_DIR/organization.id.txt
 
 # Load > Calculate annual data
-cd $DEV_DIR/gobierto/; bin/rails runner $DEV_DIR/gobierto-etl-utils/operations/gobierto_budgets/annual_data/run.rb "2021 2022" $WORKING_DIR/organization.id.txt
+cd $DEV_DIR/gobierto/; bin/rails runner $DEV_DIR/gobierto-etl-utils/operations/gobierto_budgets/annual_data/run.rb "2023 2022" $WORKING_DIR/organization.id.txt
 
 # Load > Publish activity
 cd $DEV_DIR/gobierto/; bin/rails runner $DEV_DIR/gobierto-etl-utils/operations/gobierto/publish-activity/run.rb budgets_updated $WORKING_DIR/organization.id.txt


### PR DESCRIPTION
This PR updates budgets data sources for the new year:

- introduces 2023 data source
- removes 2021 data source