### PR TITLE
Mataro / Update Debt

### DIFF
--- a/pipelines/debt/Jenkinsfile
+++ b/pipelines/debt/Jenkinsfile
@@ -21,17 +21,17 @@ pipeline {
         }
         stage('Extract > 01 file') {
             steps {
-                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/download/run.rb 'https://docs.google.com/spreadsheets/d/e/2PACX-1vSGD3Vxh7MkcBVw8c7ewGm8HlcA30XzynjQvcAC_qKNU6psd3XAig3oZIpxID0_qa3ARDPQTGNvCQDz/pub?gid=327684925&single=true&output=csv' ${WORKING_DIR}/01.csv"
+                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/download/run.rb 'https://docs.google.com/spreadsheets/d/e/2PACX-1vTWlCJ-zBt-7ktYh1R_F3_bo2AHR1m1NpeB-5xl0YQSQ7fq48C6-nRa24RuI_ySYq_C6AHUwLqeyCJa/pub?gid=500773047&single=true&output=csv' ${WORKING_DIR}/01.csv"
             }
         }
         stage('Extract > 02 file') {
             steps {
-                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/download/run.rb 'https://docs.google.com/spreadsheets/d/e/2PACX-1vQwOo3ZVkpRYdus2WHLVnqomuH9ucbdMJpKWx8MV4zUnAHHu52LmdRTIwHR7FHYu6Nc5UxSI0_Z_lV4/pub?gid=985647384&single=true&output=csv' ${WORKING_DIR}/02.csv"
+                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/download/run.rb 'https://docs.google.com/spreadsheets/d/e/2PACX-1vQpoa5CuOHTS9gNul_OoZPmBrtsguianUGJX0cne5k4M81IbGDWlVlwkqmG0r2gOanpueLTXe5KLO82/pub?gid=169495231&single=true&output=csv' ${WORKING_DIR}/02.csv"
             }
         }
         stage('Extract > 03 file') {
             steps {
-                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/download/run.rb 'https://docs.google.com/spreadsheets/d/e/2PACX-1vTXJM_fkx7G8woctEcuB5nKdIqCVIncoheSY3dbV5uOlOkFXmeHHMJ3pjWjnBec0j-FZiBJ2bA9t940/pub?gid=389343843&single=true&output=csv' ${WORKING_DIR}/03.csv"
+                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/download/run.rb 'https://docs.google.com/spreadsheets/d/e/2PACX-1vTGPYVs9gxA6zrqT3vY5w6gVRH7aH-f-CwC9pde3jIHUUWMeaY_92QKe62zPJPVbiyY8yuTEBUy_aa7/pub?gid=427327543&single=true&output=csv' ${WORKING_DIR}/03.csv"
             }
         }
         stage('Extract > Check 01 CSV format') {


### PR DESCRIPTION
Closes [#1809](https://github.com/PopulateTools/issues/issues/1809)

## :v: What does this PR do?
Updates the three URLs with the new datasets. 


## Considerations:
There are some minor differences between previous files and updated files: 

1. '01_Deute_Total_Deutor 2022 - 01_Deute_Total_Deutor 2022.csv': 
    - New raw: 'AJUNTAMENT - PENDENT RETORN PIE LIQ. NEGATIVA 2020'
    -  'CONSORCI TR. RESIDUS' value is equal to zero.
2. '02_Deute_Entitat_Creditora 2022 - 02_Deute_Entitat_Creditora 2022.csv':
    - New row: Bankinter
3. '03_evolucio_endeutament_GRUP AJUNTAMENT 2022 - 03_evolucio_endeutament_GRUP AJUNTAMENT 2022.csv':
    - 'any' row without name.