### PR TITLE
Mataro plans pipeline

### DIFF
--- a/operations/gobierto_plans/transform-projects/run.rb
+++ b/operations/gobierto_plans/transform-projects/run.rb
@@ -1,0 +1,68 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+Bundler.require
+
+# Usage:
+#
+#  - Must be ran as an independent Ruby script
+#
+# Arguments:
+#
+#  - 0: Absolute path to the source file wich is expected to contain a JSON
+#  - 1: Absoulte estination path of transformed data destination
+# Samples:
+#
+#   /path/to/project/operations/gobierto_plans/transform-projects/run.rb /tmp/mataro_plans/soruce.json /tmp/mataro_plans/transformed_data.json
+#
+
+if ARGV.length != 2
+  raise "Review the arguments"
+end
+
+source_path = ARGV[0]
+destination_path = ARGV[1]
+
+def filter_last_level_items(source_data)
+  source_data.select { |src_attrs| src_attrs["nivell"] == "6" }.reject do |src_attrs|
+    # Reject projects with no status and progress 0
+    src_attrs["l_estats"].first&.dig("codi").blank? && src_attrs["progres"] == "0"
+  end
+end
+
+def status_external_id(src_attrs)
+  src_attrs["l_estats"].first&.dig("codi") || "unknown"
+end
+
+def transformed_project_attributes(src_attrs)
+  {
+    "external_id" => src_attrs["id"],
+    "visibility_level" => "published",
+    "moderation_stage" => "approved",
+    "name_translations" => { "ca" => src_attrs["nom"], "en" => nil, "es" => nil },
+    "category_external_id" => src_attrs["id_parent"],
+    "status_external_id" => status_external_id(src_attrs),
+    "progress" => src_attrs["progres"].to_f
+  }
+end
+
+def request_body(projects_data)
+  {
+    "data" => {
+      "attributes" => {
+        "projects" => projects_data
+      }
+    }
+  }.to_json
+end
+
+puts "[START] transform-projects/run.rb with #{source_path} file"
+
+raw_data = JSON.parse(File.read(source_path)).select{ |src_attrs| src_attrs["id_plan"] == 201872 }
+
+projects_data = filter_last_level_items(raw_data).map { |src_attrs| transformed_project_attributes(src_attrs) }
+
+File.write(destination_path, request_body(projects_data))
+puts "\tCreated transformed file #{destination_path}"
+
+puts "[END] transform-projects/run.rb"

--- a/operations/gobierto_plans/upsert-projects/run.rb
+++ b/operations/gobierto_plans/upsert-projects/run.rb
@@ -1,0 +1,42 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+Bundler.require
+
+require "http"
+
+# Usage:
+#
+#  - Must be ran as an independent Ruby script
+#
+# Arguments:
+#
+#  - 0: Absolute path to the file containing the JSON body to send to the endpoint
+#  - 1: API plan endpoint t
+# Samples:
+#
+#   /path/to/project/operations/gobierto_plans/upsert-projects/run.rb body_file.json api_endpoint
+#
+
+if ARGV.length != 2
+  raise "Review the arguments"
+end
+
+body_file_path = ARGV[0]
+api_endpoint = ARGV[1]
+bearer_header = "Bearer #{ENV.fetch("API_TOKEN")}"
+
+body = File.open(body_file_path).read
+
+puts "[START] upsert-projects/run.rb with #{body_file_path} file"
+
+resp = HTTP.auth(bearer_header).put(api_endpoint, json: JSON.parse(body))
+
+if resp.status.success?
+  body = JSON.parse(resp.body.to_s)
+  puts "\tPlan with #{body.dig("data", "attributes", "projects")&.count.to_i} processes updated"
+else
+  raise StandardError, "Upsert failed"
+end
+
+puts "[END] upsert-projects/run.rb"

--- a/operations/gobierto_plans/upsert-projects/run.rb
+++ b/operations/gobierto_plans/upsert-projects/run.rb
@@ -32,11 +32,11 @@ puts "[START] upsert-projects/run.rb with #{body_file_path} file"
 
 resp = HTTP.auth(bearer_header).put(api_endpoint, json: JSON.parse(body))
 
+body = JSON.parse(resp.body.to_s)
 if resp.status.success?
-  body = JSON.parse(resp.body.to_s)
   puts "\tPlan with #{body.dig("data", "attributes", "projects")&.count.to_i} processes updated"
 else
-  raise StandardError, "Upsert failed"
+  raise StandardError, "Upsert failed: #{body.inspect}"
 end
 
 puts "[END] upsert-projects/run.rb"

--- a/pipelines/plans/Jenkinsfile
+++ b/pipelines/plans/Jenkinsfile
@@ -1,0 +1,60 @@
+email = "popu-servers+jenkins@populate.tools "
+pipeline {
+    agent any
+    environment {
+        PATH = "$HOME/.rbenv/shims:$PATH"
+        GOBIERTO_ETL_UTILS = "/var/www/gobierto-etl-utils/current/"
+        MATARO_ETL = "/var/www/gobierto-etl-mataro/current/"
+        WORKING_DIR = "/tmp/mataro_plans"
+        MATARO_ID = "8121"
+        // Variables that must be defined via Jenkins UI:
+        // GOBIERTO = "/var/www/gobierto/current"
+        // API_HOST = "https://mataro.gobify.net"
+        // PLAN_ID = "52"
+    }
+    options {
+        retry(3)
+    }
+    stages {
+        stage('Clean working dir') {
+          steps {
+              sh "rm -rf ${WORKING_DIR}"
+          }
+        }
+        stage('Extract > Download data sources - Plan data') {
+            steps {
+                sh "cd ${GOBIERTO_ETL_UTILS}; ruby operations/api-download/run.rb --source-url 'https://aplicacions.mataro.org:444/apex/rest/sigmav2/getjson/SIGMA/SEGUIMENT/id_plan/201872' --output-file ${WORKING_DIR}/plan_source_data.json"
+            }
+        }
+        stage('Transform > Transform data') {
+            steps {
+                sh "cd ${MATARO_ETL}; ruby operations/gobierto_plans/transform-projects/run.rb ${WORKING_DIR}/plan_source_data.json ${WORKING_DIR}/request_body.json"
+            }
+        }
+        stage('Load > Send create/update data to API') {
+            steps {
+                sh "cd ${MATARO_ETL}; ruby operations/gobierto_plans/upsert-projects/run.rb ${WORKING_DIR}/request_body.json ${API_HOST}/api/v1/plans${PLAN_ID}"
+            }
+        }
+        stage('Load > Publish activity') {
+            steps {
+                sh "echo '8121' > ${WORKING_DIR}/organization.id.txt"
+                sh "cd ${GOBIERTO}; bin/rails runner ${GOBIERTO_ETL_UTILS}/operations/gobierto/publish-activity/run.rb plans_projects_updated ${WORKING_DIR}/organization.id.txt"
+            }
+        }
+        stage('Clear cache') {
+            steps {
+                sh "cd ${GOBIERTO}; bin/rails runner ${GOBIERTO_ETL_UTILS}/operations/gobierto/clear-cache/run.rb --site-organization-id '${MATARO_ID}' --namespace 'GobiertoInvestments'"
+            }
+        }
+    }
+    post {
+        failure {
+            echo 'This will run only if failed'
+            mail body: "Project: ${env.JOB_NAME} - Build Number: ${env.BUILD_NUMBER} - URL de build: ${env.BUILD_URL}",
+                charset: 'UTF-8',
+                subject: "ERROR CI: Project name -> ${env.JOB_NAME}",
+                to: email
+        }
+    }
+}

--- a/pipelines/plans/Jenkinsfile
+++ b/pipelines/plans/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
         }
         stage('Load > Send create/update data to API') {
             steps {
-                sh "cd ${MATARO_ETL}; ruby operations/gobierto_plans/upsert-projects/run.rb ${WORKING_DIR}/request_body.json ${API_HOST}/api/v1/plans${PLAN_ID}"
+                sh "cd ${MATARO_ETL}; ruby operations/gobierto_plans/upsert-projects/run.rb ${WORKING_DIR}/request_body.json ${API_HOST}/api/v1/plans/${PLAN_ID}"
             }
         }
         stage('Load > Publish activity') {

--- a/pipelines/plans/dev_run.sh
+++ b/pipelines/plans/dev_run.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+source "/Users/edu/.rvm/scripts/rvm"
+set -e
+
+WORKING_DIR=/tmp/mataro_plans
+MATARO_INE_CODE=8121
+API_HOST=http://madrid.gobierto.test:3000
+PLAN_ID=57
+API_TOKEN=LUhwRCoBENVvzLUJMcuYbXkg
+
+# Clean working dir
+rm -rf $WORKING_DIR
+mkdir $WORKING_DIR
+
+# Extract > Download data sources - Plan data
+cd $DEV_DIR/gobierto-etl-utils/; ruby operations/api-download/run.rb --source-url "https://aplicacions.mataro.org:444/apex/rest/sigmav2/getjson/SIGMA/SEGUIMENT/id_plan/201872" --output-file $WORKING_DIR/plan_source_data.json
+
+# Transform > Transform data
+cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_plans/transform-projects/run.rb $WORKING_DIR/plan_source_data.json $WORKING_DIR/request_body.json
+
+# Load > Send create/update data to API
+cd $DEV_DIR/gobierto-etl-mataro/; ruby operations/gobierto_plans/upsert-projects/run.rb $WORKING_DIR/request_body.json $API_HOST/api/v1/plans/$PLAN_ID
+
+# Load > Publish activity
+echo $MATARO_INE_CODE > $WORKING_DIR/organization.id.txt
+cd $DEV_DIR/gobierto/; bin/rails runner $DEV_DIR/gobierto-etl-utils/operations/gobierto/publish-activity/run.rb plans_projects_updated $WORKING_DIR/organization.id.txt


### PR DESCRIPTION
This PR adds 2 operations to import Mataró plans:
* The transformation of the original JSON data to a JSON prepared to be processed by the gobierto plans API. The operation filters the items which has to be transformed and performs the transformations. The resulting JSON is prepared to update existing projects by their external id or create new ones if required
* The upsert operation which takes the JSON created in the previous operation and sends it to the API
The PR also adds a Jenkinsfile pipeline to complete the ETL